### PR TITLE
Fix compliance with stale-while-revalidate

### DIFF
--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -83,7 +83,9 @@ class CacheEntry
         }
 
         if ($staleWhileRevalidateTo === null && $values->has('stale-while-revalidate')) {
-            $this->staleWhileRevalidateTo = new \DateTime('+'.$values->get('stale-while-revalidate').'seconds');
+            $this->staleWhileRevalidateTo = new \DateTime(
+                '@'.($this->staleAt->getTimestamp() + (int) $values->get('stale-while-revalidate'))
+            );
         } else {
             $this->staleWhileRevalidateTo = $staleWhileRevalidateTo;
         }


### PR DESCRIPTION
RFC 5861 states that the stale-while-revalidate directive should count from the moment the cache entry becomes stale, not from the moment it is created. See section 3.1:

> A response containing:
> 
>      Cache-Control: max-age=600, stale-while-revalidate=30
> 
>    indicates that it is fresh for 600 seconds, and it may continue to be
>    served stale for up to an additional 30 seconds while an asynchronous
>    validation is attempted.  If validation is inconclusive, or if there
>    is not traffic that triggers it, after 30 seconds the stale-while-
>    revalidate function will cease to operate, and the cached response
>    will be "truly" stale (i.e., the next request will block and be
>    handled normally).